### PR TITLE
annotate EC and ACS tasks and add report container step to emit data

### DIFF
--- a/manifests/helm/build/templates/pipeline-build.yaml
+++ b/manifests/helm/build/templates/pipeline-build.yaml
@@ -111,6 +111,9 @@ spec:
       taskRef:
         kind: Task
         name: acs-image-check
+      workspaces:
+        - name: reports
+          workspace: reports
     - name: acs-image-scan
       params:
       - name: rox_central_endpoint
@@ -128,6 +131,9 @@ spec:
       taskRef:
         kind: Task
         name: acs-image-scan
+      workspaces:
+        - name: reports
+          workspace: reports
     - name: acs-deploy-check
       params:
       - name: rox_central_endpoint
@@ -149,6 +155,9 @@ spec:
         name: acs-deploy-check
       runAfter:
       - build-sign-image
+      workspaces:
+        - name: reports
+          workspace: reports
     - name: scan-export-sbom
       params:
       - name: cyclonedxHostUrl
@@ -197,7 +206,10 @@ spec:
       value: "$(tasks.git-clone.results.url)"
     - name: CHAINS-GIT_COMMIT
       value: "$(tasks.git-clone.results.commit)"
+    - name: ACS_SCAN_OUTPUT
+      value: "$(tasks.acs-image-scan.results.SCAN_OUTPUT)"
   workspaces:
     - name: source-folder
     - name: maven-settings
     - name: docker-config
+    - name: reports

--- a/manifests/helm/build/templates/task-acs-deployment-check.yaml
+++ b/manifests/helm/build/templates/task-acs-deployment-check.yaml
@@ -2,6 +2,11 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: acs-deploy-check
+  annotations:
+    task.results.format: application/json
+    task.results.type: roxctl-deployment-check
+    task.output.location: logs
+    task.results.container: step-report
 spec:
   description: >-
     Policy check a deployment with StackRox/RHACS This tasks allows you to check
@@ -117,11 +122,19 @@ spec:
         ./roxctl deployment check \
          $( [ "$(params.insecure-skip-tls-verify)" = "true" ] && \
          echo -n "--insecure-skip-tls-verify") \
-         -e "$(params.rox_central_endpoint)" --file "deployment.yaml"
+         -e "$(params.rox_central_endpoint)" --file "deployment.yaml" --output json > roxctl_deployment_check.json
+        cat roxctl_deployment_check.json >  $(workspaces.reports.path)/deployment-check
       volumeMounts:
         - mountPath: /workspace/repository
           name: repository
       workingDir: /workspace/repository
+    - image: 'quay.io/lrangine/crda-maven:11.0'
+      name: report
+      script: |
+          #!/bin/sh
+          cat $(workspaces.reports.path)/deployment-check
+  workspaces:
+    - name: reports
   volumes:
     - emptyDir: {}
       name: repository

--- a/manifests/helm/build/templates/task-acs-image-check.yaml
+++ b/manifests/helm/build/templates/task-acs-image-check.yaml
@@ -2,6 +2,11 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: acs-image-check
+  annotations:
+    task.results.format: application/json
+    task.results.type: roxctl-image-check
+    task.output.location: logs
+    task.results.container: step-report
 spec:
   description: Policy check an image with StackRox/RHACS This tasks allows you to
     check an image against build-time policies and apply enforcement to fail builds.
@@ -54,4 +59,13 @@ spec:
       ./roxctl image check \
         $( [ "$(params.insecure-skip-tls-verify)" = "true" ] && \
         echo -n "--insecure-skip-tls-verify") \
-        -e "$(params.rox_central_endpoint)" --image "$IMAGE" --force
+        -e "$(params.rox_central_endpoint)" --image "$IMAGE" --output json > roxctl_image_check.json
+      cat roxctl_image_check.json >  $(workspaces.reports.path)/image-check 
+  - image: 'quay.io/lrangine/crda-maven:11.0'
+    name: report
+    script: |
+        #!/bin/sh
+        cat $(workspaces.reports.path)/image-check
+  workspaces:
+    - name: reports
+      

--- a/manifests/helm/build/templates/task-acs-image-scan.yaml
+++ b/manifests/helm/build/templates/task-acs-image-scan.yaml
@@ -2,6 +2,12 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: acs-image-scan
+  annotations:
+    task.results.format: application/json
+    task.results.type: roxctl-image-scan
+    task.results.key: SCAN_OUTPUT
+    task.output.location: logs
+    task.results.container: step-report
 spec:
   description: Policy check an image with StackRox/RHACS This tasks allows you to
     check an image against build-time policies and apply enforcement to fail builds.
@@ -32,7 +38,7 @@ spec:
     type: string
   results:
   - description: Output of `roxctl image check`
-    name: check_output
+    name: SCAN_OUTPUT
   steps:
   - env:
     - name: ROX_API_TOKEN
@@ -54,4 +60,23 @@ spec:
       ./roxctl image scan \
         $( [ "$(params.insecure-skip-tls-verify)" = "true" ] && \
         echo -n "--insecure-skip-tls-verify") \
-        -e "$(params.rox_central_endpoint)" --image "$IMAGE" --force
+        -e "$(params.rox_central_endpoint)" --image "$IMAGE" --output json > roxctl_output.json
+      cat roxctl_output.json >  $(workspaces.reports.path)/image-scan
+  - image: 'quay.io/lrangine/crda-maven:11.0'
+    name: export-vulnerabilities
+    script: |
+        #!/bin/sh
+        jq -rce \
+        "{vulnerabilities:{
+        critical: (.result.summary.CRITICAL),
+        high: (.result.summary.IMPORTANT),
+        medium: (.result.summary.MODERATE),
+        low: (.result.summary.LOW)
+        }}" $(workspaces.reports.path)/image-scan | tee $(results.SCAN_OUTPUT.path)
+  - image: 'quay.io/lrangine/crda-maven:11.0'
+    name: report
+    script: |
+        #!/bin/sh
+        cat $(workspaces.reports.path)/image-scan
+  workspaces:
+    - name: reports

--- a/manifests/helm/build/templates/task-scan-export-sbom.yaml
+++ b/manifests/helm/build/templates/task-scan-export-sbom.yaml
@@ -2,6 +2,11 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: scan-export-sbom
+  annotations:
+    task.results.format: application/text
+    task.results.type: external-link
+    task.results.key: LINK_TO_SBOM
+    task.output.location: results
 spec:
   params:
   - default: https://cyclonedx-bom-repo-server-cyclonedx.apps.cluster-tr47n.tr47n.sandbox987.opentlc.com/
@@ -12,7 +17,7 @@ spec:
     type: string
   results:
     - description: The url location of the generate SBOM
-      name: sbomUrl
+      name: LINK_TO_SBOM
   steps:
     - name: get-sbom
       image: quay.io/redhat-appstudio/cosign:v2.1.1
@@ -37,7 +42,7 @@ spec:
 
         echo $LOCATION
 
-        printf "%s" "$LOCATION" > "$(results.sbomUrl.path)"
+        printf "%s" "$LOCATION" > "$(results.LINK_TO_SBOM.path)"
 
       workingDir: /workspace/repository
     - image: 'quay.io/redhat-gpte/grype:0.65.2'

--- a/manifests/helm/build/templates/task-verify-enterprise-contract.yaml
+++ b/manifests/helm/build/templates/task-verify-enterprise-contract.yaml
@@ -23,6 +23,10 @@ metadata:
     tekton.dev/displayName: Verify Enterprise Contract
     tekton.dev/pipelines.minVersion: "0.19"
     tekton.dev/tags: ec, chains, signature, conftest
+    task.results.format: application/json
+    task.results.type: ec
+    task.output.location: logs
+    task.results.container: step-report-json
   labels:
     app.kubernetes.io/version: "0.1"
 
@@ -104,14 +108,14 @@ spec:
       secret:
         secretName: $(params.COMPONENT_ID)-docker-config
         items:
-        - key: .dockerconfigjson
-          path: config.json
+          - key: .dockerconfigjson
+            path: config.json
     - name: rekor-public-key
       secret:
         secretName: rekor-public-key
         items:
-        - key: public.key
-          path: public.key
+          - key: public.key
+            path: public.key
 
   stepTemplate:
     env:
@@ -126,8 +130,8 @@ spec:
           oc get secret signing-secrets -n openshift-pipelines -o json > /workspace/signing-secrets
       command:
         - /bin/bash
-        - '-c'
-      image: 'quay.io/openshift/origin-cli:latest'
+        - "-c"
+      image: "quay.io/openshift/origin-cli:latest"
       name: extract-signing-secret
       resources: {}
     - image: quay.io/redhat-gpte/jq
@@ -174,10 +178,10 @@ spec:
         - "--output"
         - "json=$(params.HOMEDIR)/report-json.json"
       volumeMounts:
-      - name: docker-config
-        mountPath: $(params.HOMEDIR)/.docker
-      - name: rekor-public-key
-        mountPath: /rekor
+        - name: docker-config
+          mountPath: $(params.HOMEDIR)/.docker
+        - name: rekor-public-key
+          mountPath: /rekor
     - name: report
       image: quay.io/enterprise-contract/ec-cli:snapshot@sha256:33be4031a3316a46db3559a4d8566bc22f9d4d491d262d699614f32f35b45b67
       command: [cat]

--- a/manifests/helm/build/templates/triggertemplate-build.yaml
+++ b/manifests/helm/build/templates/triggertemplate-build.yaml
@@ -55,6 +55,8 @@ spec:
         serviceAccountName: pipeline
         timeout: 1h0m0s
         workspaces:
+          - name: reports
+            emptyDir: {}
           - name: source-folder
             volumeClaimTemplate:
               spec:


### PR DESCRIPTION

This PR contains changes (annotations and new containers which emits data) which is needed for the UI to render sbom, vulnerabilities column and output tab.

1. Annotated the following tasks with valid [RHTAP taskrun annotations](https://docs.google.com/document/d/1_1YXFx0ymzjl4b9M_LDjmmGrEYey5mDrfTdNn_56hpM/edit#heading=h.kptj2pe4x3a9):

      - **acs-image-scan**
      - **acs-image-check**
      - **acs-deploy-check**
      - **scan-export-sbom**

2. Add a new `report` container in EC and ACS tasks to emit the required data to the UI as pod logs.
3. Emit vulnerabilities in pipelineRun results (ACS_SCAN_OUTPUT)